### PR TITLE
get ready for the travis build changes

### DIFF
--- a/.atomist/executors/RestartTravisBuild.ts
+++ b/.atomist/executors/RestartTravisBuild.ts
@@ -5,7 +5,9 @@ import {Result, Status, Parameter} from "@atomist/rug/operations/RugOperation"
 class RestartTravisBuild implements Executor {
     description: string = "Executor that starts a build on Travis"
     name: string = "RestartTravisBuild"
-    parameters: Parameter[] = [{name: "build_id", description: "Build ID", pattern: "^.*$", maxLength: 100, required: true}]
+    parameters: Parameter[] = [{name: "build_id", description: "Build ID", pattern: "^.*$", maxLength: 100, required: true}
+                               {name: "token_path", description: "Access Token Path", pattern: "^.*$", required: false,
+                                tags: [{name: "token", description: "valid github token for authenticating with Travis"}]}]
     execute(services: Services, {build_id} : {build_id: string}): Result {
         let _services: any = services
         _services.travis().restart(build_id)

--- a/.atomist/executors/RestartTravisBuild.ts
+++ b/.atomist/executors/RestartTravisBuild.ts
@@ -8,9 +8,9 @@ class RestartTravisBuild implements Executor {
     parameters: Parameter[] = [{name: "build_id", description: "Build ID", pattern: "^.*$", maxLength: 100, required: true}
                                {name: "token_path", description: "Access Token Path", pattern: "^.*$", required: false,
                                 tags: [{name: "token", description: "valid github token for authenticating with Travis"}]}]
-    execute(services: Services, {build_id} : {build_id: string}): Result {
+    execute(services: Services, {build_id token_path} : {build_id: string, token_path: any}): Result {
         let _services: any = services
-        _services.travis().restart(build_id)
+        _services.travis().restart(build_id, token_path)
 
         return new Result(Status.Success, "OK")
     }

--- a/.atomist/handlers/BuildHandler.ts
+++ b/.atomist/handlers/BuildHandler.ts
@@ -2,10 +2,13 @@ import {Atomist} from '@atomist/rug/operations/Handler'
 import {TreeNode} from '@atomist/rug/tree/PathExpression'
 declare var atomist: Atomist
 
-atomist.on<TreeNode, TreeNode>("/push", m => {
-   let push = m.root()
-   let message = atomist.messageBuilder().regarding(push)
-   message.withAction(message.actionRegistry().findByName("RestartTravisBuild"))
+atomist.on<TreeNode, TreeNode>("/build[.status()='Failed']", m => {
+   let build = m.root()
+   let message = atomist.messageBuilder().regarding(build)
+   let action = message.actionRegistry().findByName("RestartTravisBuild")
+   let parameter: ParameterValue = {:name "build_id" :value build.id()}
+   action.parameters.push(parameter)
+   message.withAction(action)
    message.send()
 })
 


### PR DESCRIPTION
Note two things:
1.  I've added a token_path parameter to the RestartTravisBuild because the bot needs to be able to query the rug-catalog to find out that it must send a token_path along with the command (and ensure that this token_path has an authorized token)
2.  I've altered one of the BuildHandler.ts handlers to partially apply the build_id parameter to the action.  This looks really ugly and what I'd like to see is more something like:

```typescript
let action = message.actionRegistry().findByName("RestartTravisBuild").addParameter("build_id", build.id())
```

* but it looks like adding a function to the TypeScript interface for Action requires corresponding changes in scala?
* second question is whether we should explicitly add a Parameter constructor to the Typescript model.  Is that idiomatic in typescript?
