### PR TITLE
adds a TypeScript Rug editor to a Rug project

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -52,3 +52,19 @@ editor:
     - "description": "Simple command to tag a sha in GitHub"
     - "intent": "create tag"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "AddTypeScriptEditor"
+  group: "atomist"
+  artifact: "rug-rugs"
+  version: "0.29.0"
+  origin:
+    repo: "https://github.com/atomist/rug-rugs.git"
+    branch: "0f425945c62957ccc2ccb63e9980e6f78b97a4a1"
+    sha: "0f42594"
+  parameters:
+    - "editorName": "Test"
+    - "description": "Test"
+

--- a/.atomist/editors/Test.ts
+++ b/.atomist/editors/Test.ts
@@ -1,0 +1,28 @@
+import { Project } from "@atomist/rug/model/Project";
+import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
+import { EditProject } from "@atomist/rug/operations/ProjectEditor";
+import { Pattern } from "@atomist/rug/operations/RugOperation";
+
+/**
+ * Sample TypeScript editor used by AddTest.
+ */
+@Editor("Test", "Test")
+@Tags("documentation")
+export class Test implements EditProject {
+
+    @Parameter({
+        displayName: "Some Input",
+        description: "example of how to specify a parameter using decorators",
+        pattern: Pattern.any,
+        validInput: "a description of the valid input",
+        minLength: 1,
+        maxLength: 100,
+    })
+    public inputParameter: string;
+
+    public edit(project: Project) {
+        project.addFile("hello.txt", "Hello, World!\n" + this.inputParameter + "\n");
+    }
+}
+
+export const test = new Test();

--- a/.atomist/tests/project/TestSteps.ts
+++ b/.atomist/tests/project/TestSteps.ts
@@ -1,0 +1,12 @@
+import { Project } from "@atomist/rug/model/Project";
+import { Given, ProjectScenarioWorld, Then, When } from "@atomist/rug/test/project/Core";
+
+When("the Test is run", (p, world) => {
+    const w = world as ProjectScenarioWorld;
+    const editor = w.editor("Test");
+    w.editWith(editor, { inputParameter: "the inputParameter value" });
+});
+
+Then("the hello file says hello", (p, world) => {
+    return p.fileContains("hello.txt", "Hello, World!");
+});

--- a/.atomist/tests/project/TestTest.feature
+++ b/.atomist/tests/project/TestTest.feature
@@ -1,0 +1,10 @@
+Feature: Make sure the sample TypeScript Editor has some tests
+  This is just a sample Gherkin feature file for the
+  Test.
+
+  Scenario: Test is added to your project by AddTest
+    Given the archive root
+    When the Test is run
+    Then parameters were valid
+    Then changes were made
+    Then the hello file says hello


### PR DESCRIPTION
Created by Atomist Editor `AddTypeScriptEditor`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddTypeScriptEditor"
  group: "atomist"
  artifact: "rug-rugs"
  version: "0.29.0"
  origin:
    repo: "https://github.com/atomist/rug-rugs.git"
    branch: "0f425945c62957ccc2ccb63e9980e6f78b97a4a1"
    sha: "0f42594"
  parameters:
    - "editorName": "Test"
    - "description": "Test"

```