### PR TITLE
Receive build notifications via Atomist

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -52,3 +52,19 @@ editor:
     - "description": "Simple command to tag a sha in GitHub"
     - "intent": "create tag"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170816122823"
+editor:
+  name: "AddTravisWebhookEditor"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.3.68"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs.git"
+    branch: "1ef47a3059e4fbb20326ff4365c4ef7f06502165"
+    sha: "1ef47a3"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook-staging.atomist.services/atomist/travis/teams/T1L0VDKJP"
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.atomist.yml linguist-generated=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,15 @@ notifications:
   email: false
   webhooks:
     urls:
-    - https://webhook.atomist.com/travis
-    - https://webhook-staging.atomist.services/travis
+    - 'https://webhook.atomist.com/travis'
+    - 'https://webhook-staging.atomist.services/travis'
+    - >-
+        https://webhook-staging.atomist.services/atomist/travis/teams/T1L0VDKJP/undefined
     on_success: always
     on_failure: always
     on_start: always
+    on_cancel: always
+    on_error: always
 cache:
   directories:
   - "$HOME/.atomist"


### PR DESCRIPTION
Send build events to Atomist.

They'll be incorporated into GitHub push and PR notifications,
so you'll see dynamically updated build results along with your commits.
Look for them in this channel in Slack.

[Travis webhook documentation](https://docs.travis-ci.com/user/notifications/#Configuring-webhook-notifications)